### PR TITLE
fix: update voyage-context-4 ARN to v1-0-1

### DIFF
--- a/deploy_mongodb_voyage_model_package_sagemaker.ipynb
+++ b/deploy_mongodb_voyage_model_package_sagemaker.ipynb
@@ -218,7 +218,7 @@
     "    \"voyage-3-large\": \"voyage-3-large-updated-4cefad4269b037efa49eb078a2db522e\",\n",
     "    \"voyage-code-3\": \"voyage-code-3-22d7879593f334709185560a458771a5\",\n",
     "    \"voyage-context-3\": \"voyage-context-3-v1-0-1-01db2e1a4fe938478cd46724c50d6152\",\n",
-    "    \"voyage-context-4\": \"voyage-context-4-v1-0-0-d9596503ede73c2ba686816637a377e3\",\n",
+    "    \"voyage-context-4\": \"voyage-context-4-v1-0-1-0697eda5606835738ed1c6ff5036b16c\",\n",
     "    \"voyage-4\": \"voyage-4-v2-6b74695ad99635b8a2aefb616dd663ae\",\n",
     "    \"voyage-4-lite\": \"voyage-4-lite-v3-75769a90d6cb3a43b0ab6c5e17c69f7f\",\n",
     "    \"voyage-4-large\": \"voyage-4-large-v7-e94b111dd9f33116808770d646aff38c\",\n",


### PR DESCRIPTION
## Summary
- Updates the voyage-context-4 model package ARN resource ID from v1-0-0 to v1-0-1 (0697eda5606835738ed1c6ff5036b16c) in the MongoDB SageMaker deployment notebook.

## Test plan
- [ ] N/A, ARN reference update only