### PR TITLE
docs: document batch transform model and instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,36 @@
 
 Notebooks and sample payloads for deploying VoyageAI models via AWS SageMaker.
 
+> [!WARNING]
+> **`deploy_voyage_model_package_sagemaker.ipynb` is deprecated.** It covers the older model catalogue (the voyage-3 and voyage-2 families, `rerank-2`) and does not receive new models. Use **`deploy_mongodb_voyage_model_package_sagemaker.ipynb`** for all current deployments.
+
 ## Docs
 
 - https://www.mongodb.com/docs/voyageai/management/aws-marketplace/
 - https://docs.voyageai.com/docs/aws-marketplace-mongodb-voyage
+
+## Model support
+
+Models available through `deploy_mongodb_voyage_model_package_sagemaker.ipynb`.
+
+| Model | Real-time endpoint | Batch transform |
+|---|---|---|
+| voyage-4 | Yes | Yes |
+| voyage-4-lite | Yes | Yes |
+| voyage-4-large | Yes | No (1) |
+| voyage-3.5, voyage-3.5-lite | Yes | Yes |
+| voyage-3-large, voyage-code-3 | Yes | Yes |
+| voyage-context-3 | Yes | Yes |
+| voyage-context-4 | Yes | No (1) |
+| voyage-multimodal-3.5, voyage-multimodal-3 | Yes | Yes |
+| rerank-2.5, rerank-2.5-lite | Yes | No (2) |
+
+1. Requires a GPU family AWS does not offer for [batch transform jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) (G7e class or above). Real-time endpoints only until AWS extends batch transform hardware support.
+2. Reranking scores candidates against a query at request time, so it is a real-time operation. Batch transform is not offered for rerankers.
+
+### Batch transform configuration
+
+Batch transform jobs must use `BatchStrategy="SingleRecord"` with `SplitType="Line"` and JSON Lines input (`application/jsonlines`), one complete request per line. `MultiRecord` batching, other split types, and other content types such as CSV are not supported. See [CreateTransformJob](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html) and [TransformInput](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_TransformInput.html) for the full set of AWS options.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Models available through `deploy_mongodb_voyage_model_package_sagemaker.ipynb`.
 | voyage-3.5-lite | Yes | Yes |
 | voyage-3-large | Yes | Yes |
 | voyage-code-3 | Yes | Yes |
-| voyage-code-4 | Yes (3) | Yes (3) |
+| voyage-code-4 | Yes | Yes |
 | voyage-context-3 | Yes | Yes |
 | voyage-context-4 | Yes | No (1) |
 | voyage-multimodal-3.5 | Yes | Yes |
@@ -33,7 +33,6 @@ Models available through `deploy_mongodb_voyage_model_package_sagemaker.ipynb`.
 
 1. Requires a GPU family AWS does not offer for [batch transform jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) (G7e class or above). Real-time endpoints only until AWS extends batch transform hardware support.
 2. Reranking scores candidates against a query at request time, so it is a real-time operation. Batch transform is not offered for rerankers.
-3. Pending marketplace listing. `voyage-code-4` is not yet selectable in the notebook, which has no model package ARN for it.
 
 ### Batch transform configuration
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ Models available through `deploy_mongodb_voyage_model_package_sagemaker.ipynb`.
 | voyage-4 | Yes | Yes |
 | voyage-4-lite | Yes | Yes |
 | voyage-4-large | Yes | No (1) |
-| voyage-3.5, voyage-3.5-lite | Yes | Yes |
-| voyage-3-large, voyage-code-3 | Yes | Yes |
+| voyage-3.5 | Yes | Yes |
+| voyage-3.5-lite | Yes | Yes |
+| voyage-3-large | Yes | Yes |
+| voyage-code-3 | Yes | Yes |
+| voyage-code-4 | Yes (3) | Yes (3) |
 | voyage-context-3 | Yes | Yes |
 | voyage-context-4 | Yes | No (1) |
-| voyage-multimodal-3.5, voyage-multimodal-3 | Yes | Yes |
-| rerank-2.5, rerank-2.5-lite | Yes | No (2) |
+| voyage-multimodal-3.5 | Yes | Yes |
+| voyage-multimodal-3 | Yes | Yes |
+| rerank-2.5 | Yes | No (2) |
+| rerank-2.5-lite | Yes | No (2) |
 
 1. Requires a GPU family AWS does not offer for [batch transform jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) (G7e class or above). Real-time endpoints only until AWS extends batch transform hardware support.
 2. Reranking scores candidates against a query at request time, so it is a real-time operation. Batch transform is not offered for rerankers.
+3. Pending marketplace listing. `voyage-code-4` is not yet selectable in the notebook, which has no model package ARN for it.
 
 ### Batch transform configuration
 

--- a/deploy_mongodb_voyage_model_package_sagemaker.ipynb
+++ b/deploy_mongodb_voyage_model_package_sagemaker.ipynb
@@ -92,10 +92,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Real-time endpoints: every family below is valid.\n",
     "# P4 instances are Nvidia A100 GPUs. P5 instances are Nvidia H100 GPUs.\n",
     "# G5 instances are Nvidia A10G GPUs. G6 instances are Nvidia L4 GPUs.\n",
     "# G7e instances are Nvidia RTX PRO 6000 Blackwell Server Edition GPUs.\n",
-    "# \"ml.p4d.24xlarge\", \"ml.p4e.24xlarge\", \"ml.p5.48xlarge\",\n",
+    "# \"ml.p4d.24xlarge\", \"ml.p4de.24xlarge\", \"ml.p5.48xlarge\",\n",
     "# \"ml.g5.xlarge\", \"ml.g5.2xlarge\", \"ml.g5.4xlarge\", \"ml.g5.8xlarge\",\n",
     "# \"ml.g5.16xlarge\", \"ml.g5.24xlarge\", \"ml.g5.48xlarge\"\n",
     "# \"ml.g6.xlarge\", \"ml.g6.2xlarge\", \"ml.g6.4xlarge\", \"ml.g6.8xlarge\",\n",
@@ -103,6 +104,10 @@
     "# \"ml.g7e.2xlarge\", \"ml.g7e.4xlarge\", \"ml.g7e.8xlarge\",\n",
     "# \"ml.g7e.12xlarge\", \"ml.g7e.24xlarge\", \"ml.g7e.48xlarge\"\n",
     "ENDPOINT_INSTANCE = \"ml.g6.xlarge\"\n",
+    "\n",
+    "# Batch transform: G5 and G6 only.  AWS does not offer P4, P5 or G7e instances for\n",
+    "# batch transform jobs, so setting BATCH_INSTANCE to one of those fails at job creation.\n",
+    "# See https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_TransformResources.html\n",
     "BATCH_INSTANCE = \"ml.g5.2xlarge\""
    ]
   },
@@ -183,15 +188,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Models that are not available as batch transform jobs, and why.\n",
+    "# The two reasons are different: the MoE models are blocked by an AWS hardware limit\n",
+    "# that may lift, the rerankers are a deliberate product boundary.\n",
+    "BATCH_TRANSFORM_UNSUPPORTED = {\n",
+    "    \"voyage-4-large\": (\n",
+    "        \"requires a GPU family that AWS does not offer for batch transform jobs. \"\n",
+    "        \"Use a real-time endpoint instead.\"\n",
+    "    ),\n",
+    "    \"voyage-context-4\": (\n",
+    "        \"requires a GPU family that AWS does not offer for batch transform jobs. \"\n",
+    "        \"Use a real-time endpoint instead.\"\n",
+    "    ),\n",
+    "    \"rerank-2.5\": (\n",
+    "        \"is a reranker.  Reranking scores candidates against a query at request time, \"\n",
+    "        \"so it is a real-time operation.  Use a real-time endpoint instead.\"\n",
+    "    ),\n",
+    "    \"rerank-2.5-lite\": (\n",
+    "        \"is a reranker.  Reranking scores candidates against a query at request time, \"\n",
+    "        \"so it is a real-time operation.  Use a real-time endpoint instead.\"\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "\n",
     "# Checks if a model (specified by a model ID) supports batch transform jobs\n",
     "def model_supports_batch_transform(model_id):\n",
-    "    unsupported_batch_transform_models = [\n",
-    "        \"rerank-2.5\",\n",
-    "        \"rerank-2.5-lite\",\n",
-    "        \"voyage-4-large\",\n",
-    "        \"voyage-context-4\",\n",
-    "    ]\n",
-    "    return model_id not in unsupported_batch_transform_models"
+    "    return model_id not in BATCH_TRANSFORM_UNSUPPORTED"
    ]
   },
   {
@@ -883,7 +905,7 @@
    "source": [
     "The batch transform job example supports text embedding models, the `voyage-context-3` contextualized embedding model, and multimodal embedding models.  The input format differs between model types: standard text models use a flat `input` string per JSONL line, `voyage-context-3` uses a nested `inputs` array of arrays per JSONL line, and multimodal models use a pre-built sample input file containing content arrays with text and base64-encoded image entries.\n",
     "\n",
-    "**Note:** Batch transform jobs are not supported for reranker models (`rerank-2.5`, `rerank-2.5-lite`), `voyage-4-large`, or `voyage-context-4`."
+    "**Note:** Batch transform jobs are not available for `voyage-4-large` or `voyage-context-4`, which require a GPU family AWS does not offer for batch transform, nor for the rerankers (`rerank-2.5`, `rerank-2.5-lite`), because reranking scores candidates against a query at request time and is therefore a real-time operation.  All four are available as real-time endpoints."
    ]
   },
   {
@@ -981,7 +1003,7 @@
    "outputs": [],
    "source": [
     "if not model_supports_batch_transform(MODEL_ID):\n",
-    "    print(f\"{MODEL_ID} does not support batch transform jobs.\")\n",
+    "    print(f\"{MODEL_ID} {BATCH_TRANSFORM_UNSUPPORTED[MODEL_ID]}\")\n",
     "elif model_is_text_embedding(MODEL_ID):\n",
     "    with open(INPUT_FILE_NAME_EMBEDDING, \"w\") as f:\n",
     "        for index, doc in enumerate(documents):\n",
@@ -1046,7 +1068,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4.3 Initialize batch transformer"
+    "## 4.3 Initialize batch transformer\n",
+    "\n",
+    "Only `strategy=\"SingleRecord\"` with `split_type=\"Line\"` is supported, and the input file must be JSON Lines (`application/jsonlines`) with one complete request per line.  The model server reads exactly one JSON object per call, so `MultiRecord` batching (which sends several records in a single request body), other split types, and other content types such as CSV will fail.  See [CreateTransformJob](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html) and [TransformInput](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_TransformInput.html) for the full set of AWS options."
    ]
   },
   {
@@ -1107,7 +1131,7 @@
     "        f\"\\nSuccessfully completed {MODEL_ID} batch transform job on {BATCH_INSTANCE} in {str(elapsed_time_batch)} seconds.\"\n",
     "    )\n",
     "else:\n",
-    "    print(f\"{MODEL_ID} does not support batch transform jobs.\")"
+    "    print(f\"{MODEL_ID} {BATCH_TRANSFORM_UNSUPPORTED[MODEL_ID]}\")"
    ]
   }
  ],


### PR DESCRIPTION
Nothing stated which models support batch transform jobs, or which instance types are valid for them, until a job failed at creation. The README now carries a per-model support matrix and documents the `SingleRecord`/`Line` and JSON Lines constraints with links to the AWS API reference, and flags `deploy_voyage_model_package_sagemaker.ipynb` as deprecated.

In the MongoDB notebook, the instance comment block is split into real-time and batch lists (AWS offers no P4, P5 or G7e for batch transform), `ml.p4e.24xlarge` is corrected to `ml.p4de.24xlarge` since the former is not a real instance type, and the bare exclusion list becomes a reason map so the skip message tells the customer what to do instead.

The two exclusion classes are deliberately worded differently: `voyage-4-large` and `voyage-context-4` are blocked by an AWS hardware limit that may lift, while the rerankers are a product boundary, since reranking scores candidates against a query at request time.